### PR TITLE
AOP特性微调

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -3,15 +3,16 @@
 $header = <<<'EOF'
 This file is part of Swoft.
 
-@link https://swoft.org
+@link     https://swoft.org
 @document https://doc.swoft.org
-@contact group@swoft.org
-@license https://github.com/swoft-cloud/swoft/blob/master/LICENSE
+@contact  group@swoft.org
+@license  https://github.com/swoft-cloud/swoft/blob/master/LICENSE
 EOF;
 
 return PhpCsFixer\Config::create()
     ->setRiskyAllowed(true)
     ->setRules([
+        '@PSR2' => true,
         'header_comment' => [
             'commentType' => 'PHPDoc',
             'header' => $header,
@@ -21,6 +22,10 @@ return PhpCsFixer\Config::create()
             'syntax' => 'short'
         ],
         'single_quote' => true,
+        'class_attributes_separation' => true,
+        'no_unused_imports' => true,
+        'standardize_not_equals' => true,
+
     ])
     ->setFinder(
         PhpCsFixer\Finder::create()

--- a/src/Aop/Aop.php
+++ b/src/Aop/Aop.php
@@ -7,6 +7,7 @@
  * @contact group@swoft.org
  * @license https://github.com/swoft-cloud/swoft/blob/master/LICENSE
  */
+
 namespace Swoft\Aop;
 
 use Swoft\Bean\Annotation\Bean;
@@ -83,7 +84,7 @@ class Aop implements AopInterface
                     // The result of before point will not effect origin object method
                     $this->doPoint($advice['before'], $target, $method, $params, $advice, $advices);
                 }
-                if(0 === count($advices)) {
+                if(0 === \count($advices)) {
                     $result = $target->$method(...$params);
                 } else {
                     $this->doAdvice($target, $method, $params, $advices);
@@ -96,7 +97,7 @@ class Aop implements AopInterface
             }
         } catch (Throwable $t) {
             if (isset($advice['afterThrowing']) && ! empty($advice['afterThrowing'])) {
-                return $this->doPoint($advice['afterThrowing'], $target, $method, $params, $advice, $advices,null,$t);
+                return $this->doPoint($advice['afterThrowing'], $target, $method, $params, $advice, $advices, null, $t);
             }else{
                 throw $t;
             }
@@ -132,7 +133,7 @@ class Aop implements AopInterface
         array $advice,
         array $advices,
         $return = null,
-        Throwable $catch=null
+        Throwable $catch = null
     ) {
         list($aspectClass, $aspectMethod) = $pointAdvice;
 
@@ -152,7 +153,7 @@ class Aop implements AopInterface
             // JoinPoint object
             $type = $parameterType->__toString();
             if ($type === JoinPoint::class) {
-                $aspectArgs[] = new JoinPoint($target, $method, $args, $return,$catch);
+                $aspectArgs[] = new JoinPoint($target, $method, $args, $return, $catch);
                 continue;
             }
 
@@ -163,7 +164,7 @@ class Aop implements AopInterface
             }
             
             //Throwable object
-            if (isset($catch) && $catch instanceof  $type){
+            if (isset($catch) && $catch instanceof $type){
                 $aspectArgs[] = $catch;
                 continue;
             }
@@ -261,7 +262,7 @@ class Aop implements AopInterface
             }
 
             // Method
-            $reg = '/^' . $executionMethod . '$/';
+            $reg = '/^(?:' . $executionMethod . ')$/';
             if (preg_match($reg, $method)) {
                 return true;
             }

--- a/src/Aop/Aop.php
+++ b/src/Aop/Aop.php
@@ -2,10 +2,10 @@
 /**
  * This file is part of Swoft.
  *
- * @link https://swoft.org
+ * @link     https://swoft.org
  * @document https://doc.swoft.org
- * @contact group@swoft.org
- * @license https://github.com/swoft-cloud/swoft/blob/master/LICENSE
+ * @contact  group@swoft.org
+ * @license  https://github.com/swoft-cloud/swoft/blob/master/LICENSE
  */
 
 namespace Swoft\Aop;
@@ -84,7 +84,7 @@ class Aop implements AopInterface
                     // The result of before point will not effect origin object method
                     $this->doPoint($advice['before'], $target, $method, $params, $advice, $advices);
                 }
-                if(0 === \count($advices)) {
+                if (0 === \count($advices)) {
                     $result = $target->$method(...$params);
                 } else {
                     $this->doAdvice($target, $method, $params, $advices);
@@ -98,7 +98,7 @@ class Aop implements AopInterface
         } catch (Throwable $t) {
             if (isset($advice['afterThrowing']) && ! empty($advice['afterThrowing'])) {
                 return $this->doPoint($advice['afterThrowing'], $target, $method, $params, $advice, $advices, null, $t);
-            }else{
+            } else {
                 throw $t;
             }
         }
@@ -159,12 +159,12 @@ class Aop implements AopInterface
 
             // ProceedingJoinPoint object
             if ($type === ProceedingJoinPoint::class) {
-                $aspectArgs[] = new ProceedingJoinPoint  ($target, $method, $args, $advice, $advices);
+                $aspectArgs[] = new ProceedingJoinPoint($target, $method, $args, $advice, $advices);
                 continue;
             }
             
             //Throwable object
-            if (isset($catch) && $catch instanceof $type){
+            if (isset($catch) && $catch instanceof $type) {
                 $aspectArgs[] = $catch;
                 continue;
             }

--- a/src/Aop/JoinPoint.php
+++ b/src/Aop/JoinPoint.php
@@ -7,7 +7,9 @@
  * @contact group@swoft.org
  * @license https://github.com/swoft-cloud/swoft/blob/master/LICENSE
  */
+
 namespace Swoft\Aop;
+
 use \Throwable;
 
 /**
@@ -55,7 +57,7 @@ class JoinPoint implements JoinPointInterface
      * @param mixed  $return the return of executed method
      * @param Throwable $catch the throwable caught of the origin
      */
-    public function __construct($target, string $method, array $args, $return = null,$catch=null)
+    public function __construct($target, string $method, array $args, $return = null, $catch = null)
     {
         $this->args   = $args;
         $this->return = $return;
@@ -99,7 +101,8 @@ class JoinPoint implements JoinPointInterface
     /**
      * @return null|Throwable
      */
-    public function getCatch(){
+    public function getCatch()
+    {
         return $this->catch;
     }
 }

--- a/src/Aop/JoinPoint.php
+++ b/src/Aop/JoinPoint.php
@@ -1,6 +1,14 @@
 <?php
-
+/**
+ * This file is part of Swoft.
+ *
+ * @link https://swoft.org
+ * @document https://doc.swoft.org
+ * @contact group@swoft.org
+ * @license https://github.com/swoft-cloud/swoft/blob/master/LICENSE
+ */
 namespace Swoft\Aop;
+use \Throwable;
 
 /**
  * the join point of class
@@ -34,19 +42,26 @@ class JoinPoint implements JoinPointInterface
     protected $method;
 
     /**
+     * @var Throwable
+     */
+    protected $catch;
+    
+    /**
      * JoinPoint constructor.
      *
      * @param object $target the object of origin
      * @param string $method the method of origin
      * @param array  $args   the params of method
      * @param mixed  $return the return of executed method
+     * @param Throwable $catch the throwable caught of the origin
      */
-    public function __construct($target, string $method, array $args, $return = null)
+    public function __construct($target, string $method, array $args, $return = null,$catch=null)
     {
         $this->args   = $args;
         $this->return = $return;
         $this->target = $target;
         $this->method = $method;
+        $this->catch  = $catch;
     }
 
     /**
@@ -79,5 +94,12 @@ class JoinPoint implements JoinPointInterface
     public function getMethod(): string
     {
         return $this->method;
+    }
+
+    /**
+     * @return null|Throwable
+     */
+    public function getCatch(){
+        return $this->catch;
     }
 }

--- a/src/Aop/JoinPoint.php
+++ b/src/Aop/JoinPoint.php
@@ -2,10 +2,10 @@
 /**
  * This file is part of Swoft.
  *
- * @link https://swoft.org
+ * @link     https://swoft.org
  * @document https://doc.swoft.org
- * @contact group@swoft.org
- * @license https://github.com/swoft-cloud/swoft/blob/master/LICENSE
+ * @contact  group@swoft.org
+ * @license  https://github.com/swoft-cloud/swoft/blob/master/LICENSE
  */
 
 namespace Swoft\Aop;

--- a/test/Cases/Aop/AllPointAspectWithoutRound1.php
+++ b/test/Cases/Aop/AllPointAspectWithoutRound1.php
@@ -2,19 +2,17 @@
 /**
  * This file is part of Swoft.
  *
- * @link https://swoft.org
+ * @link     https://swoft.org
  * @document https://doc.swoft.org
- * @contact group@swoft.org
- * @license https://github.com/swoft-cloud/swoft/blob/master/LICENSE
+ * @contact  group@swoft.org
+ * @license  https://github.com/swoft-cloud/swoft/blob/master/LICENSE
  */
 namespace SwoftTest\Aop;
 
 use Swoft\Aop\JoinPoint;
-use Swoft\Aop\ProceedingJoinPoint;
 use Swoft\Bean\Annotation\After;
 use Swoft\Bean\Annotation\AfterReturning;
 use Swoft\Bean\Annotation\AfterThrowing;
-use Swoft\Bean\Annotation\Around;
 use Swoft\Bean\Annotation\Aspect;
 use Swoft\Bean\Annotation\Before;
 use Swoft\Bean\Annotation\PointBean;
@@ -35,7 +33,6 @@ use Swoft\Bean\Annotation\PointBean;
  */
 class AllPointAspectWithoutRound1
 {
-
     /**
      * @var \Throwable
      */
@@ -67,13 +64,11 @@ class AllPointAspectWithoutRound1
 
     /**
      * @param JoinPoint $joinPoint
-     * @throws 
+     * @throws
      * @AfterThrowing
      */
-    public function afterThrowing(JoinPoint $joinPoint){
+    public function afterThrowing(JoinPoint $joinPoint)
+    {
         static::$catch=$joinPoint->getCatch();
-
     }
-
-    
 }

--- a/test/Cases/Aop/AllPointAspectWithoutRound1.php
+++ b/test/Cases/Aop/AllPointAspectWithoutRound1.php
@@ -36,6 +36,10 @@ use Swoft\Bean\Annotation\PointBean;
 class AllPointAspectWithoutRound1
 {
 
+    /**
+     * @var \Throwable
+     */
+    public static $catch;
 
     /**
      * @Before()
@@ -61,6 +65,15 @@ class AllPointAspectWithoutRound1
         echo ' afterReturn1withoutaround ';
     }
 
+    /**
+     * @param JoinPoint $joinPoint
+     * @throws 
+     * @AfterThrowing
+     */
+    public function afterThrowing(JoinPoint $joinPoint){
+        static::$catch=$joinPoint->getCatch();
+        throw $joinPoint->getCatch();
+    }
 
     
 }

--- a/test/Cases/Aop/AllPointAspectWithoutRound1.php
+++ b/test/Cases/Aop/AllPointAspectWithoutRound1.php
@@ -42,7 +42,7 @@ class AllPointAspectWithoutRound1
      */
     public function before()
     {
-        echo ' before1withoutatound ';
+        echo ' before1withoutaround ';
     }
 
     /**
@@ -50,7 +50,7 @@ class AllPointAspectWithoutRound1
      */
     public function after()
     {
-        echo ' after1withoutatound ';
+        echo ' after1withoutaround ';
     }
 
     /**
@@ -58,7 +58,7 @@ class AllPointAspectWithoutRound1
      */
     public function afterReturn()
     {
-        echo ' afterReturn1withoutatound ';
+        echo ' afterReturn1withoutaround ';
     }
 
 

--- a/test/Cases/Aop/AllPointAspectWithoutRound1.php
+++ b/test/Cases/Aop/AllPointAspectWithoutRound1.php
@@ -72,7 +72,7 @@ class AllPointAspectWithoutRound1
      */
     public function afterThrowing(JoinPoint $joinPoint){
         static::$catch=$joinPoint->getCatch();
-        throw $joinPoint->getCatch();
+
     }
 
     

--- a/test/Cases/Aop/AllPointAspectWithoutRound2.php
+++ b/test/Cases/Aop/AllPointAspectWithoutRound2.php
@@ -35,6 +35,12 @@ use Swoft\Bean\Annotation\PointBean;
 class AllPointAspectWithoutRound2
 {
     /**
+     * @var \Exception
+     */
+    public static $catch;
+
+    
+    /**
      * @Before()
      */
     public function before()
@@ -59,4 +65,12 @@ class AllPointAspectWithoutRound2
     }
 
 
+    /**
+     * @param \Exception $e
+     * @AfterThrowing
+     */
+    public function afterThrowing(\Exception $e=null){
+        static::$catch=$e;
+    }
+    
 }

--- a/test/Cases/Aop/AllPointAspectWithoutRound2.php
+++ b/test/Cases/Aop/AllPointAspectWithoutRound2.php
@@ -2,19 +2,16 @@
 /**
  * This file is part of Swoft.
  *
- * @link https://swoft.org
+ * @link     https://swoft.org
  * @document https://doc.swoft.org
- * @contact group@swoft.org
- * @license https://github.com/swoft-cloud/swoft/blob/master/LICENSE
+ * @contact  group@swoft.org
+ * @license  https://github.com/swoft-cloud/swoft/blob/master/LICENSE
  */
 namespace SwoftTest\Aop;
 
-use Swoft\Aop\JoinPoint;
-use Swoft\Aop\ProceedingJoinPoint;
 use Swoft\Bean\Annotation\After;
 use Swoft\Bean\Annotation\AfterReturning;
 use Swoft\Bean\Annotation\AfterThrowing;
-use Swoft\Bean\Annotation\Around;
 use Swoft\Bean\Annotation\Aspect;
 use Swoft\Bean\Annotation\Before;
 use Swoft\Bean\Annotation\PointBean;
@@ -38,7 +35,6 @@ class AllPointAspectWithoutRound2
      * @var \Exception
      */
     public static $catch;
-
     
     /**
      * @Before()
@@ -64,15 +60,14 @@ class AllPointAspectWithoutRound2
         echo ' afterReturn2withoutaround ';
     }
 
-
     /**
      * @param \Exception $e
      * @AfterThrowing
-     * @throws 
+     * @throws
      */
-    public function afterThrowing(\Exception $e=null){
+    public function afterThrowing(\Exception $e=null)
+    {
         static::$catch=$e;
         throw $e;
     }
-    
 }

--- a/test/Cases/Aop/AllPointAspectWithoutRound2.php
+++ b/test/Cases/Aop/AllPointAspectWithoutRound2.php
@@ -68,9 +68,11 @@ class AllPointAspectWithoutRound2
     /**
      * @param \Exception $e
      * @AfterThrowing
+     * @throws 
      */
     public function afterThrowing(\Exception $e=null){
         static::$catch=$e;
+        throw $e;
     }
     
 }

--- a/test/Cases/Aop/AllPointAspectWithoutRound2.php
+++ b/test/Cases/Aop/AllPointAspectWithoutRound2.php
@@ -39,7 +39,7 @@ class AllPointAspectWithoutRound2
      */
     public function before()
     {
-        echo ' before2withoutatound ';
+        echo ' before2withoutaround ';
     }
 
     /**
@@ -47,7 +47,7 @@ class AllPointAspectWithoutRound2
      */
     public function after()
     {
-        echo ' after2withoutatound ';
+        echo ' after2withoutaround ';
     }
 
     /**
@@ -55,7 +55,7 @@ class AllPointAspectWithoutRound2
      */
     public function afterReturn()
     {
-        echo ' afterReturn2withoutatound ';
+        echo ' afterReturn2withoutaround ';
     }
 
 

--- a/test/Cases/Aop/AopBean2.php
+++ b/test/Cases/Aop/AopBean2.php
@@ -27,4 +27,9 @@ class AopBean2
         echo 'do aop';
     }
     
+    
+    public function throwSth(\Throwable $t){
+        throw $t;
+    }
+    
 }

--- a/test/Cases/Aop/AopBean2.php
+++ b/test/Cases/Aop/AopBean2.php
@@ -2,10 +2,10 @@
 /**
  * This file is part of Swoft.
  *
- * @link https://swoft.org
+ * @link     https://swoft.org
  * @document https://doc.swoft.org
- * @contact group@swoft.org
- * @license https://github.com/swoft-cloud/swoft/blob/master/LICENSE
+ * @contact  group@swoft.org
+ * @license  https://github.com/swoft-cloud/swoft/blob/master/LICENSE
  */
 namespace SwoftTest\Aop;
 
@@ -27,9 +27,8 @@ class AopBean2
         echo 'do aop';
     }
     
-    
-    public function throwSth(\Throwable $t){
+    public function throwSth(\Throwable $t)
+    {
         throw $t;
     }
-    
 }

--- a/test/Cases/AopTest.php
+++ b/test/Cases/AopTest.php
@@ -2,10 +2,10 @@
 /**
  * This file is part of Swoft.
  *
- * @link https://swoft.org
+ * @link     https://swoft.org
  * @document https://doc.swoft.org
- * @contact group@swoft.org
- * @license https://github.com/swoft-cloud/swoft/blob/master/LICENSE
+ * @contact  group@swoft.org
+ * @license  https://github.com/swoft-cloud/swoft/blob/master/LICENSE
  */
 namespace SwoftTest;
 
@@ -35,7 +35,6 @@ class AopTest extends AbstractTestCase
         $result = $aopBean->doAop();
         $this->assertEquals('do aop around-before2  before2  around-after2  afterReturn2  around-before1  before1  around-after1  afterReturn1 ', $result);
     }
-
 
     /**
      * 验证问题:当切面不包含Around型通知时，不支持多层切面
@@ -84,12 +83,12 @@ class AopTest extends AbstractTestCase
         $this->assertEquals('methodParams-a-new-b-new regAspect around before  regAspect around after ', $result);
     }
 
-
     /**
      * 测试AfterThrowing切面 能否从JoinPoint获取异常
      * @author Jiankang maijiankang@foxmail.com
      */
-    public function testThrowableInjectByJoinPoint(){
+    public function testThrowableInjectByJoinPoint()
+    {
         /* @var \SwoftTest\Aop\AopBean2 $aopBean*/
         $aopBean = App::getBean(AopBean2::class);
         AllPointAspectWithoutRound1::$catch=null;
@@ -99,15 +98,15 @@ class AopTest extends AbstractTestCase
         $aopBean->throwSth($exception);
 
         ob_end_clean();
-        $this->assertEquals($exception,AllPointAspectWithoutRound1::$catch);
-
+        $this->assertEquals($exception, AllPointAspectWithoutRound1::$catch);
     }
 
     /**
      * 测试AfterThrowing切面 能否直接注入异常
      * @author Jiankang maijiankang@foxmail.com
      */
-    public function testThrowableInject(){
+    public function testThrowableInject()
+    {
         /* @var \SwoftTest\Aop\AopBean2 $aopBean*/
         $aopBean = App::getBean(AopBean2::class);
         AllPointAspectWithoutRound2::$catch=null;
@@ -117,8 +116,6 @@ class AopTest extends AbstractTestCase
         $aopBean->throwSth($exception);
 
         ob_end_clean();
-        $this->assertEquals($exception,AllPointAspectWithoutRound2::$catch);
-
+        $this->assertEquals($exception, AllPointAspectWithoutRound2::$catch);
     }
-    
 }

--- a/test/Cases/AopTest.php
+++ b/test/Cases/AopTest.php
@@ -49,7 +49,7 @@ class AopTest extends AbstractTestCase
         $echoContent=ob_get_contents();
         ob_end_clean();
         
-        $this->assertEquals(' before1withoutatound  before2withoutatound do aop after2withoutatound  afterReturn2withoutatound  after1withoutatound  afterReturn1withoutatound ', $echoContent);
+        $this->assertEquals(' before1withoutaround  before2withoutaround do aop after2withoutaround  afterReturn2withoutaround  after1withoutaround  afterReturn1withoutaround ', $echoContent);
     }
     
     public function testAnnotationAop()

--- a/test/Cases/AopTest.php
+++ b/test/Cases/AopTest.php
@@ -93,11 +93,12 @@ class AopTest extends AbstractTestCase
         /* @var \SwoftTest\Aop\AopBean2 $aopBean*/
         $aopBean = App::getBean(AopBean2::class);
         AllPointAspectWithoutRound1::$catch=null;
-
         $exception=new \LogicException('Bomb!');
+        ob_start();
 
         $aopBean->throwSth($exception);
 
+        ob_end_clean();
         $this->assertEquals($exception,AllPointAspectWithoutRound1::$catch);
 
     }
@@ -110,11 +111,12 @@ class AopTest extends AbstractTestCase
         /* @var \SwoftTest\Aop\AopBean2 $aopBean*/
         $aopBean = App::getBean(AopBean2::class);
         AllPointAspectWithoutRound2::$catch=null;
-
         $exception=new \LogicException('Bomb!');
+        ob_start();
 
         $aopBean->throwSth($exception);
 
+        ob_end_clean();
         $this->assertEquals($exception,AllPointAspectWithoutRound2::$catch);
 
     }

--- a/test/Cases/AopTest.php
+++ b/test/Cases/AopTest.php
@@ -10,6 +10,8 @@
 namespace SwoftTest;
 
 use Swoft\App;
+use SwoftTest\Aop\AllPointAspectWithoutRound1;
+use SwoftTest\Aop\AllPointAspectWithoutRound2;
 use SwoftTest\Aop\AnnotationAop;
 use SwoftTest\Aop\AopBean;
 use SwoftTest\Aop\AopBean2;
@@ -81,4 +83,40 @@ class AopTest extends AbstractTestCase
         $result = $annotationBean->methodParams('a', 'b');
         $this->assertEquals('methodParams-a-new-b-new regAspect around before  regAspect around after ', $result);
     }
+
+
+    /**
+     * 测试AfterThrowing切面 能否从JoinPoint获取异常
+     * @author Jiankang maijiankang@foxmail.com
+     */
+    public function testThrowableInjectByJoinPoint(){
+        /* @var \SwoftTest\Aop\AopBean2 $aopBean*/
+        $aopBean = App::getBean(AopBean2::class);
+        AllPointAspectWithoutRound1::$catch=null;
+
+        $exception=new \LogicException('Bomb!');
+
+        $aopBean->throwSth($exception);
+
+        $this->assertEquals($exception,AllPointAspectWithoutRound1::$catch);
+
+    }
+
+    /**
+     * 测试AfterThrowing切面 能否直接注入异常
+     * @author Jiankang maijiankang@foxmail.com
+     */
+    public function testThrowableInject(){
+        /* @var \SwoftTest\Aop\AopBean2 $aopBean*/
+        $aopBean = App::getBean(AopBean2::class);
+        AllPointAspectWithoutRound2::$catch=null;
+
+        $exception=new \LogicException('Bomb!');
+
+        $aopBean->throwSth($exception);
+
+        $this->assertEquals($exception,AllPointAspectWithoutRound2::$catch);
+
+    }
+    
 }


### PR DESCRIPTION
-  既然已经要求环境PHP7.0+，没必要只catch expetion，直接catch throwable
-  原机制是存在切面即屏蔽异常，不太合理。改为没有@AfterThrowing的切面原异常向上层切面继续抛出，存在@AfterThrowing的切面由@AfterThrowing决定是否向上抛出异常  __(该点前向不兼容)__
-  @AfterThrowing 需要有获取异常信息的能力，故在JoinPoint添加Throwable成员；作为快捷方式,在异常通知中可以通过声明通知参数类型直接获取特定类型异常。