### PR TITLE
fix a bug when warnings appear in the high version of swoole

### DIFF
--- a/src/Testing/SwooleResponse.php
+++ b/src/Testing/SwooleResponse.php
@@ -53,8 +53,9 @@ class SwooleResponse extends \Swoole\Http\Response
     /**
      * 设置HttpCode，如404, 501, 200
      * @param $code
+     * @param $reason
      */
-    public function status($code)
+    public function status($code, $reason = NULL)
     {
     }
 

--- a/src/Testing/SwooleResponse.php
+++ b/src/Testing/SwooleResponse.php
@@ -52,8 +52,8 @@ class SwooleResponse extends \Swoole\Http\Response
 
     /**
      * 设置HttpCode，如404, 501, 200
-     * @param $code
-     * @param $reason
+     * @param int $code
+     * @param string $reason
      */
     public function status($code, $reason = NULL)
     {


### PR DESCRIPTION
#### version:
swoole 4.1

#### Message:
PHP Warning:  Declaration of Swoft\Testing\SwooleResponse::status($code) should be compatible with Swoole\Http\Response::status($http_code, $reason = NULL)
